### PR TITLE
Add ws headers

### DIFF
--- a/services/elixir/Dockerfile
+++ b/services/elixir/Dockerfile
@@ -1,8 +1,4 @@
-FROM erlang:27
-
-# elixir expects utf8.
-ENV ELIXIR_VERSION="v1.17.2" \
-	LANG=C.UTF-8
+FROM elixir:latest
 
 ARG GROUPID
 ARG USERID
@@ -14,19 +10,7 @@ USER root
 RUN groupadd -g ${GROUPID} ${GROUP_NAME} && \
     useradd -u ${USERID} -g ${GROUPID} -m ${USER_NAME}
 
-RUN set -xe \
-	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="7bb8e6414b77c1707f39f620a2ad54f68d64846d663ec78069536854247fb1ab" \
-	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
-	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
-	&& mkdir -p /usr/local/src/elixir \
-	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
-	&& rm elixir-src.tar.gz \
-	&& cd /usr/local/src/elixir \
-	&& make install clean \
-	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
-	&& find /usr/local/src/elixir/ -type d -depth -empty -delete
-
+RUN apt update && apt -y install inotify-tools
 WORKDIR /projects
 
 USER ${USERID}

--- a/services/nginx/sites/elixir.conf
+++ b/services/nginx/sites/elixir.conf
@@ -5,6 +5,8 @@ server {
         proxy_set_header   X-Forwarded-For $remote_addr;
         proxy_set_header   Host $http_host;
         proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_http_version 1.1;
         proxy_pass         http://elixir:4000;
     }
 }


### PR DESCRIPTION
Add websocket headers to elixir.conf to enable websocket connections for phoenix framework. Also add inotify to elixir container and simplify dockerfile.